### PR TITLE
Stripe email webhook fixes

### DIFF
--- a/vdgsa_backend/stripe_email_webhook/views.py
+++ b/vdgsa_backend/stripe_email_webhook/views.py
@@ -39,6 +39,10 @@ def stripe_officer_email_view(request: HttpRequest, *args: Any, **kwargs: Any) -
             event.data.object.id, limit=100
         )
 
+        metadata_str = 'Metadata:\n'
+        for key, value in event.data.object.metadata.items():
+            metadata_str += f'{key}: {value}\n'
+
         customer_email = event.data.object.customer_email
         for item in line_items.data:
             product = stripe.Product.retrieve(item.price.product)
@@ -53,7 +57,8 @@ def stripe_officer_email_view(request: HttpRequest, *args: Any, **kwargs: Any) -
                 message=f'{customer_email} has made a '
                         f'{item.price.unit_amount / 100:.2f}{item.price.currency} '
                         f'payment of type "{product.name}".\n\n'
-                        f'Description: {item.description}'
+                        f'Description: {product.description}\n\n'
+                        + metadata_str
             )
 
         return HttpResponse('Emails sent')


### PR DESCRIPTION
- Add checkout session metadata to stripe emails
- Correctly include description