### PR TITLE
Implemented membership directory and CSV download tweaks

### DIFF
--- a/vdgsa_backend/accounts/models.py
+++ b/vdgsa_backend/accounts/models.py
@@ -74,7 +74,7 @@ class User(AbstractUser):
 
     @property
     def subscription(self) -> Optional[MembershipSubscription]:
-        if hasattr(self, 'owned_subscription'):
+        if self.is_primary_membership_holder:
             return self.owned_subscription
 
         return self.subscription_is_family_member_for
@@ -91,6 +91,10 @@ class User(AbstractUser):
             self.subscription.valid_until is not None
             and timezone.now() <= self.subscription.valid_until
         )
+
+    @property
+    def is_primary_membership_holder(self) -> bool:
+        return hasattr(self, 'owned_subscription')
 
     def save(self, *args: Any, **kwargs: Any) -> None:
         # User.email is used by some out-of-the-box features (like

--- a/vdgsa_backend/accounts/tests/test_views/test_membership_secretary_view.py
+++ b/vdgsa_backend/accounts/tests/test_views/test_membership_secretary_view.py
@@ -139,6 +139,8 @@ class _TestData(Protocol):
     user4_current_subscription: MembershipSubscription
     user7_lifetime_subscription: MembershipSubscription
 
+    # user1_deceased: User
+
 
 def _test_data_init(test_obj: _TestData) -> None:
     test_obj.num_users = 10
@@ -157,6 +159,15 @@ def _test_data_init(test_obj: _TestData) -> None:
     test_obj.membership_secretary.user_permissions.add(
         Permission.objects.get(codename='membership_secretary')
     )
+
+    MembershipSubscription.objects.create(
+        owner=test_obj.users[1],
+        membership_type=MembershipType.lifetime,
+        valid_until=None,
+        years_renewed=[2020]
+    )
+    test_obj.users[1].is_deceased = True
+    test_obj.users[1].save()
 
     test_obj.user0_expired_subscription = MembershipSubscription.objects.create(
         owner=test_obj.users[0],


### PR DESCRIPTION
1) Remove deceased members from the Active category
2) Add a CSV field to indicate is_primary_membership_holder, which will be False for all family members
3) Add a CSV field to indicate primary_membership_email, so it's easy to link users who share the same address (even if they have different last names)